### PR TITLE
Feature/method ordering internal

### DIFF
--- a/src/main/kotlin/ktlintrules/MethodsOrderingRule.kt
+++ b/src/main/kotlin/ktlintrules/MethodsOrderingRule.kt
@@ -36,17 +36,19 @@ class MethodsOrderingRule : Rule("methods-ordering-rule") {
         return when (text) {
             Modifiers.OVERRIDE -> 0
             Modifiers.PUBLIC -> 1
-            Modifiers.PROTECTED -> 2
-            Modifiers.OPEN -> 3
-            Modifiers.ABSTRACT -> 4
-            Modifiers.PRIVATE -> 5
-            Modifiers.INLINE -> 6
+            Modifiers.INTERNAL -> 2
+            Modifiers.PROTECTED -> 3
+            Modifiers.OPEN -> 4
+            Modifiers.ABSTRACT -> 5
+            Modifiers.PRIVATE -> 6
+            Modifiers.INLINE -> 7
             else -> Int.MAX_VALUE
         }
     }
 
     object Modifiers {
         val PUBLIC = null
+        const val INTERNAL = "internal"
         const val OVERRIDE = "override"
         const val PROTECTED = "protected"
         const val OPEN = "open"

--- a/src/main/kotlin/ktlintrules/MethodsOrderingRule.kt
+++ b/src/main/kotlin/ktlintrules/MethodsOrderingRule.kt
@@ -2,14 +2,11 @@ package ktlintrules
 
 import com.pinterest.ktlint.core.Rule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.lexer.KtTokens.*
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
-import org.jetbrains.kotlin.psi.stubs.KotlinModifierListStub
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
-import org.jetbrains.kotlin.util.capitalizeDecapitalize.capitalizeFirstWord
 
 class MethodsOrderingRule : Rule("methods-ordering-rule") {
     override fun visit(
@@ -33,13 +30,13 @@ class MethodsOrderingRule : Rule("methods-ordering-rule") {
         return with(function) {
             when {
                 isPublic -> Modifiers.PUBLIC
-                hasModifier(KtTokens.OVERRIDE_KEYWORD) -> Modifiers.OVERRIDE
-                hasModifier(KtTokens.INTERNAL_KEYWORD) -> Modifiers.INTERNAL
-                hasModifier(KtTokens.PROTECTED_KEYWORD) -> Modifiers.PROTECTED
-                hasModifier(KtTokens.OPEN_KEYWORD) -> Modifiers.OPEN
-                hasModifier(KtTokens.ABSTRACT_KEYWORD) -> Modifiers.ABSTRACT
-                hasModifier(KtTokens.PRIVATE_KEYWORD) -> Modifiers.PRIVATE
-                hasModifier(KtTokens.INLINE_KEYWORD) -> Modifiers.INLINE
+                hasModifier(OVERRIDE_KEYWORD) -> Modifiers.OVERRIDE
+                hasModifier(INTERNAL_KEYWORD) -> Modifiers.INTERNAL
+                hasModifier(PROTECTED_KEYWORD) -> Modifiers.PROTECTED
+                hasModifier(OPEN_KEYWORD) -> Modifiers.OPEN
+                hasModifier(ABSTRACT_KEYWORD) -> Modifiers.ABSTRACT
+                hasModifier(PRIVATE_KEYWORD) -> Modifiers.PRIVATE
+                hasModifier(INLINE_KEYWORD) -> Modifiers.INLINE
                 else -> Modifiers.PUBLIC
             }
         }

--- a/src/test/kotlin/ktlint/MethodsOrderingRuleTest.kt
+++ b/src/test/kotlin/ktlint/MethodsOrderingRuleTest.kt
@@ -113,4 +113,90 @@ class MethodsOrderingRuleTest {
                 )
         ).isEmpty()
     }
+
+    @Test
+    fun internalMethodTestRule() {
+        Assertions.assertThat(
+                MethodsOrderingRule().lint("""
+           class TrainingDashboardViewModel @Inject constructor() : BaseViewModel() {
+
+    val date: LiveData<Date> get() = dateLiveData
+    val datePicked: LiveData<Event<Calendar>> get() = datePickedLiveData
+
+    private val dateLiveData: MutableLiveData<Date> = MutableLiveData()
+    private val datePickedLiveData: MutableLiveData<Event<Calendar>> = MutableLiveData()
+
+    private var localDate: Date = Date()
+    private var localDatePicked: Calendar = Calendar.getInstance()
+
+    internal fun onNextDayClicked() {
+        dateLiveData.value = localDate.addDays(1)
+    }
+
+    internal fun onPreviousDayClicked() {
+        dateLiveData.value = localDate.backDays(1)
+    }
+
+    internal fun onDiaryClicked() {
+        datePickedLiveData.value = Event(localDatePicked)
+    }
+
+    internal fun onDateChosen() {
+        localDate = localDatePicked.time
+        dateLiveData.value = localDate
+    }
+
+    private fun onCreate() {
+        dateLiveData.value = localDate
+    }
+}
+        """.trimIndent()
+                )
+        ).isEmpty()
+    }
+
+    @Test
+    fun publicInternalProtectedTestRule() {
+        Assertions.assertThat(
+                MethodsOrderingRule().lint("""
+           class PublicInternalProtected  {
+
+    fun onNextDayClicked() {
+        dateLiveData.value = localDate.addDays(1)
+    }
+
+    internal fun onPreviousDayClicked() {
+        dateLiveData.value = localDate.backDays(1)
+    }
+
+    protected fun onDiaryClicked() {
+        datePickedLiveData.value = Event(localDatePicked)
+    }
+}
+        """.trimIndent()
+                )
+        ).isEmpty()
+    }
+
+    @Test
+    fun protectedInternalTestRule() {
+        Assertions.assertThat(
+                MethodsOrderingRule().lint("""
+           class ProtectedInternal  {
+
+    protected fun onNextDayClicked() {
+        dateLiveData.value = localDate.addDays(1)
+    }
+
+    internal fun onPreviousDayClicked() {
+        dateLiveData.value = localDate.backDays(1)
+    }
+}
+        """.trimIndent()
+                )
+        ).containsExactly(
+                LintError(1, 12, "methods-ordering-rule",
+                        "Methods are in the wrong order")
+        )
+    }
 }

--- a/src/test/kotlin/ktlint/MethodsOrderingRuleTest.kt
+++ b/src/test/kotlin/ktlint/MethodsOrderingRuleTest.kt
@@ -57,7 +57,7 @@ class MethodsOrderingRuleTest {
     }
 
     @Test
-    fun annotatedMethodsOrderRule() {
+    fun annotatedMethodsOrderRuleInternalAfterPublic() {
         Assertions.assertThat(
                 MethodsOrderingRule().lint("""
            class LogInTest {
@@ -69,13 +69,6 @@ class MethodsOrderingRuleTest {
     var coroutinesTestRule = CoroutinesTestRule()
 
     private lateinit var logIn: LogIn
-
-    @Before
-    fun setup() {
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            logIn = LogIn(returnMockedRepository())
-        }
-    }
 
     @ExperimentalCoroutinesApi
     @Test
@@ -100,6 +93,13 @@ class MethodsOrderingRuleTest {
                     assert(e is InvalidFieldsException)
                 }
             }
+        }
+    }
+    
+    @Before
+    internal fun setup() {
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            logIn = LogIn(returnMockedRepository())
         }
     }
 
@@ -146,6 +146,7 @@ class MethodsOrderingRuleTest {
         dateLiveData.value = localDate
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
     private fun onCreate() {
         dateLiveData.value = localDate
     }


### PR DESCRIPTION
Desenvolvido: Troca da lógica de como encontrar os modificadores de visibilidade das funções.

Comentários: Existe um método chamado `hasModifier` da `KtNamedFunction` que recebe um `KtModifierKeywordToken`. 

E existe uma interface chama `KtTokens` que possui vários desses `KtModifierKeywordToken` (os que eu usei são os de visibilidade, mas existem outros pra pegarem se é comentário, `const`, um `elvis`, um monte de coisa)

(Demorou, mas venci a preguiça)