### PR TITLE
Feature/redundant qualifier

### DIFF
--- a/src/main/kotlin/ktlintrules/CustomRuleSetProvider.kt
+++ b/src/main/kotlin/ktlintrules/CustomRuleSetProvider.kt
@@ -4,5 +4,9 @@ import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 
 class CustomRuleSetProvider : RuleSetProvider {
-    override fun get() = RuleSet("jera-ktlint-rules", MethodsOrderingRule())
+    override fun get() = RuleSet(
+        "melgarejo-ktlint-rules",
+        MethodsOrderingRule(),
+        RedundantQualifierRule()
+    )
 }

--- a/src/main/kotlin/ktlintrules/MethodsOrderingRule.kt
+++ b/src/main/kotlin/ktlintrules/MethodsOrderingRule.kt
@@ -2,13 +2,19 @@ package ktlintrules
 
 import com.pinterest.ktlint.core.Rule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.lexer.KtTokens.*
+import org.jetbrains.kotlin.lexer.KtTokens.ABSTRACT_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.INLINE_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.INTERNAL_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.OPEN_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.OVERRIDE_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.PRIVATE_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.PROTECTED_KEYWORD
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
-class MethodsOrderingRule : Rule(ERROR_ID) {
+class MethodsOrderingRule : Rule(RULE_ID) {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
@@ -21,7 +27,7 @@ class MethodsOrderingRule : Rule(ERROR_ID) {
                     resolveFunctionModifier(function)
                 }
                 if (originalMappedModifiers != originalMappedModifiers.sortedBy { it }) {
-                    emit(node.startOffset, ERROR_MESSAGE, false)
+                    emit(node.startOffset, RULE_DESCRIPTION, false)
                 }
             }
         }
@@ -44,8 +50,8 @@ class MethodsOrderingRule : Rule(ERROR_ID) {
     }
 
     companion object {
-        const val ERROR_ID = "methods-ordering-rule"
-        const val ERROR_MESSAGE: String = "Methods are in the wrong order, the right one, should be:\n" +
+        const val RULE_ID = "methods-ordering-rule"
+        const val RULE_DESCRIPTION: String = "Methods are in the wrong order, the right one, should be:\n" +
             "PUBLIC\n" +
             "INTERNAL\n" +
             "OVERRIDE\n" +

--- a/src/main/kotlin/ktlintrules/RedundantQualifierRule.kt
+++ b/src/main/kotlin/ktlintrules/RedundantQualifierRule.kt
@@ -1,0 +1,19 @@
+package ktlintrules
+
+import com.pinterest.ktlint.core.Rule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+class RedundantQualifierRule : Rule(RULE_ID) {
+
+    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        if (node.elementType == KtStubElementTypes.CLASS) {
+
+        }
+    }
+
+    companion object {
+        const val RULE_ID = "redundant-qualifier-name"
+
+    }
+}

--- a/src/main/kotlin/ktlintrules/RedundantQualifierRule.kt
+++ b/src/main/kotlin/ktlintrules/RedundantQualifierRule.kt
@@ -2,18 +2,39 @@ package ktlintrules
 
 import com.pinterest.ktlint.core.Rule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class RedundantQualifierRule : Rule(RULE_ID) {
+    private val importPaths = mutableListOf<String>()
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
-        if (node.elementType == KtStubElementTypes.CLASS) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        when (node.elementType) {
+            KtStubElementTypes.CLASS -> resolveRuleForClass(node, emit)
+            KtStubElementTypes.IMPORT_DIRECTIVE -> (node.psi as? KtImportDirective)?.importPath?.fqName?.asString()?.let(importPaths::add)
+        }
+    }
 
+    private fun resolveRuleForClass(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        (node.psi as? KtClass)?.body?.declarations?.filterIsInstance<KtProperty>()?.forEach { property ->
+            importPaths.forEach {
+                if (property.text.contains(it)) emit(node.startOffset, RULE_DESCRIPTION, false)
+            }
         }
     }
 
     companion object {
         const val RULE_ID = "redundant-qualifier-name"
+        const val RULE_DESCRIPTION: String = "Qualifier name is redundant. Remove import or remove qualifier"
 
     }
 }

--- a/src/test/kotlin/ktlintrules/MethodsOrderingRuleTest.kt
+++ b/src/test/kotlin/ktlintrules/MethodsOrderingRuleTest.kt
@@ -1,8 +1,7 @@
-package ktlint
+package ktlintrules
 
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.lint
-import ktlintrules.MethodsOrderingRule
 import org.assertj.core.api.Assertions
 import org.junit.Test
 
@@ -27,8 +26,8 @@ class MethodsOrderingRuleTest {
             }
         """.trimIndent()
         )).containsExactly(
-                LintError(1, 1, MethodsOrderingRule.ERROR_ID,
-                        MethodsOrderingRule.ERROR_MESSAGE)
+                LintError(1, 1, MethodsOrderingRule.RULE_ID,
+                        MethodsOrderingRule.RULE_DESCRIPTION)
         )
     }
 
@@ -196,8 +195,8 @@ class MethodsOrderingRuleTest {
         """.trimIndent()
                 )
         ).containsExactly(
-                LintError(1, 12, MethodsOrderingRule.ERROR_ID,
-                        MethodsOrderingRule.ERROR_MESSAGE)
+                LintError(1, 12, MethodsOrderingRule.RULE_ID,
+                        MethodsOrderingRule.RULE_DESCRIPTION)
         )
     }
 }

--- a/src/test/kotlin/ktlintrules/RedundantQualifierRuleTest.kt
+++ b/src/test/kotlin/ktlintrules/RedundantQualifierRuleTest.kt
@@ -1,0 +1,39 @@
+package ktlintrules
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class RedundantQualifierRuleTest {
+    @Test
+    fun redundantQualifierRule() {
+        Assertions.assertThat(RedundantQualifierRule().lint("""
+            import com.example.application.ClassExample
+            
+            class Foo : DummyInterface {
+                val variable1 = 1
+                private val variable2 = 2
+                private var example: com.example.application.ClassExample? = null
+            }
+        """.trimIndent()
+        )).containsExactly(
+            LintError(3, 1, RedundantQualifierRule.RULE_ID,
+                RedundantQualifierRule.RULE_DESCRIPTION)
+        )
+    }
+
+    @Test
+    fun noRedundantQualifierRule() {
+        Assertions.assertThat(RedundantQualifierRule().lint("""
+            import com.example.application.ClassExample
+            
+            class Foo : DummyInterface {
+                val variable1 = 1
+                private val variable2 = 2
+                private var example: ClassExample? = null
+            }
+        """.trimIndent()
+        )).isEmpty()
+    }
+}


### PR DESCRIPTION
Added rule to verify if the code has one or more instances of redundant qualifier name, which means the class has imports and through the code uses a full path of the qualifier